### PR TITLE
Add Native Instruments Traktor Kontrol S2 MK3 support (WIP)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .DS_Store
 *.ini
 *__pycache__
+*.broken

--- a/README.MD
+++ b/README.MD
@@ -32,7 +32,7 @@ pip3 install -r requirements.txt
 ```
 5. Copy and replace the DDJ-SX Mapping in Rekordbox' installation folder with the files found in "pioneer_mappings"
 ```bash
-MACOSPATH_HERE
+cp "pioneer_mappings/PIONEER DDJ-SX.midi.csv" "/Applications/rekordbox 7/rekordbox.app/Contents/Resources/MidiMappings/PIONEER DDJ-SX.midi.csv"
 ```
 
 ## Installation Windows

--- a/README.MD
+++ b/README.MD
@@ -10,6 +10,8 @@ This program allows jog wheels and pitch control on third-party controllers to w
     -   Mix
 - Numark
     -   Mixtrack 3
+- Native Instruments
+    -   Traktor Kontrol S2 MK3 (work in progress — see notes below)
 
 To use it with other controllers, you'll need to find the MIDI calls and their pattern using MIDI-OX or a similar tool and modify the source code accordingly. Feel free to send a Pull Request!
 
@@ -78,6 +80,19 @@ You need to go to "MIDI" and change the Setting for PIONEER DDJ-SX Tempo from 0h
 ### Allen & Heath Xone:4D
 
 For better precision, 2 faders are used for each deck pitch control. 2-nd fader increments smaller values.
+
+### Native Instruments Traktor Kontrol S2 MK3 (work in progress)
+
+To put the S2 MK3 into MIDI mode: hold the **LEFT FLX button** while connecting the USB cable. The pads flash green once MIDI mode is active.
+
+Launch with:
+```bash
+python3 RekordJog_KontrolS2MK3.py
+```
+
+Supported: jogwheels (rotation + touch), tempo faders, deck buttons + shift layer, performance pads (incl. shift), browse encoder, loop/move encoders (incl. shift → BeatJump), mixer faders/EQ/gain, crossfader, headphone cue, FX select + FX/filter knob, load button.
+
+**Known limitation:** the browse encoder's press action (`BROWSE_PRESS_NOTE`) is not yet mapped — the exact MIDI note it sends hasn't been identified. It's disabled (`None`) rather than guessed. Everything else has been tested on real hardware. Helper scripts used to reverse-engineer the mapping (`capture_s2mk3_midi.py`, `learn_buttons.py`, `test_midi_input.py`) are included for anyone continuing this work.
 
 ## For Developers:
 ### How to map jog wheels

--- a/RekordJog_KontrolS2MK3.py
+++ b/RekordJog_KontrolS2MK3.py
@@ -1,0 +1,577 @@
+import os
+import mido
+from functions.check_config import check_config
+from functions.rekordjog_start_sequence import rekordjog_start_sequence
+
+
+# =============================================================================
+# RekordJog for Native Instruments Traktor Kontrol S2 MK3
+# =============================================================================
+# MIDI Mode: Hold LEFT FLX button while connecting USB cable.
+#            Pads flash green to confirm MIDI mode is active.
+#
+# S2 MK3 MIDI channel scheme:
+#   Ch1  (0x91/0xB1) = Deck A (left)        → DDJ-SX ch0
+#   Ch3  (0x93/0xB3) = Deck B (right)       → DDJ-SX ch1
+#   Ch2  (0x92/0xB2) = Deck A + Shift       → DDJ-SX ch0 (shift variants)
+#   Ch4  (0x94/0xB4) = Deck B + Shift       → DDJ-SX ch1 (shift variants)
+#   Ch5  (0x95/0xB5) = Left mixer channel
+#   Ch6  (0x96/0xB6) = Right mixer channel
+#   Ch7  (0x97/0xB7) = Global mixer
+#
+# DDJ-SX pad channel scheme:
+#   Deck A pads → ch7 (0x97), Deck B pads → ch8 (0x98)
+# =============================================================================
+
+# Amplify jog sensitivity. S2 sends values centered at 64 (range ~56-70).
+# Factor of 3 maps ±6 to ±18 for DDJ-SX. Increase for more aggressive scratch.
+JOG_AMPLIFY = 3
+
+# How many DDJ-SX jog messages per S2 jog message. Start with 1.
+JOG_MULTIPLIER = 1
+
+
+# ---------------------------------------------------------------------------
+# Jogwheel rotation  (S2: CC 0x1E on Ch1/Ch3, relative, center=64)
+# ---------------------------------------------------------------------------
+JOG_CODES = {
+    (0xB1, 0x1E): 0,  # Deck A (left)
+    (0xB3, 0x1E): 1,  # Deck B (right)
+}
+
+# ---------------------------------------------------------------------------
+# Jogwheel touch  (S2: Note 0x14, vel 127=on / 0=off, Ch1/Ch3)
+# ---------------------------------------------------------------------------
+TOUCH_CODES = {
+    (0x91, 0x14): 0,  # Deck A
+    (0x93, 0x14): 1,  # Deck B
+}
+
+# ---------------------------------------------------------------------------
+# Tempo/Pitch fader  (S2: CC 0x2A on Ch1/Ch3, absolute 0-127)
+# DDJ-SX: 14-bit via CC 0x00 (MSB) + CC 0x20 (LSB)
+# ---------------------------------------------------------------------------
+TEMPO_CODES = {
+    (0xB1, 0x2A): 0,  # Deck A
+    (0xB3, 0x2A): 1,  # Deck B
+}
+
+# ---------------------------------------------------------------------------
+# Per-deck buttons  (S2: Note on Ch1=Deck A, Ch3=Deck B)
+# Maps S2_note → DDJ_note, sent on DDJ deck channel (ch0=A, ch1=B)
+# Verified via learn_buttons.py capture.
+# ---------------------------------------------------------------------------
+DECK_BUTTON_MAP = {
+    # Transport
+    0x01: 0x0B,  # Play/Pause          → DDJ PlayPause
+    0x02: 0x0C,  # Cue                 → DDJ Cue
+    0x10: 0x58,  # Sync                → DDJ Sync
+    0x15: 0x15,  # Reverse/Slip        → DDJ SlipReverse/Censor
+    0x0F: 0x1A,  # KeyLock/Master      → DDJ MasterTempo/KeyLock
+    # Loop encoder press (touch 0x28 is in IGNORED_NOTES)
+    0x1C: 0x14,  # Loop Encoder press  → DDJ AutoLoop
+    # Pad mode buttons (above pads)
+    0x0B: 0x1B,  # HotCues             → DDJ HotCueMode
+    0x0C: 0x22,  # Samples             → DDJ SamplerMode
+    # FLX
+    0x16: 0x1E,  # FLX                 → DDJ PadFx1Mode
+    # Grid
+    0x0D: 0x0A,  # Grid                → DDJ GridSlide
+}
+
+# ---------------------------------------------------------------------------
+# Shift-layer buttons  (S2: same notes but on Ch2=A+Shift, Ch4=B+Shift)
+# Maps S2_note → DDJ shift-variant note, sent on DDJ deck channel
+# ---------------------------------------------------------------------------
+SHIFT_BUTTON_MAP = {
+    0x01: 0x47,  # Shift+Play          → DDJ PlayPause+Shift
+    0x02: 0x48,  # Shift+Cue           → DDJ JumpToTrackStart
+    0x10: 0x5C,  # Shift+Sync          → DDJ Master On/Off
+    0x15: 0x38,  # Shift+Reverse       → DDJ Reverse
+    0x0F: 0x60,  # Shift+KeyLock       → DDJ TempoRange
+    0x1C: 0x50,  # Shift+LoopPress     → DDJ ActiveLoop toggle
+    0x0B: 0x69,  # Shift+HotCues(MOVE) → DDJ BeatJump mode
+    0x0C: 0x41,  # Shift+Samples(LOOP) → DDJ VelocitySampler mode
+    0x16: 0x6B,  # Shift+FLX           → DDJ PadFx2Mode
+    0x0D: 0x65,  # Shift+Grid          → DDJ GridAdjustDouble
+}
+
+# ---------------------------------------------------------------------------
+# Performance pads  (S2: Notes 0x03-0x0A on Ch1/Ch3, 8 pads)
+# DDJ-SX HotCue pads: Notes 0x00-0x07 on ch7 (Deck A) / ch8 (Deck B)
+# Shift+pads (delete hotcue): Notes 0x08-0x0F on ch7/ch8
+# ---------------------------------------------------------------------------
+PAD_FIRST_NOTE = 0x03   # S2 pad 1 starts at note 0x03
+PAD_LAST_NOTE  = 0x0A   # S2 pad 8 ends at note 0x0A
+
+# ---------------------------------------------------------------------------
+# Browse encoder  (S2: CC 0x19 on Ch1/Ch3, relative, center=64)
+# DDJ-SX Browse: CC 0x40 on ch6
+# Both encoders (left/right deck) control the same browser.
+# ---------------------------------------------------------------------------
+BROWSE_CODES = {
+    (0xB1, 0x19),  # Left deck browse encoder
+    (0xB3, 0x19),  # Right deck browse encoder
+}
+
+# Browse encoder press (S2 note TBD — press generates a Note, not CC)
+# DDJ-SX: Forward/Browse+Press = Note 0x41 on ch6 (0x96 0x41)
+# Set to None to disable; set to the S2 note number once identified.
+BROWSE_PRESS_NOTE = None  # e.g. 0x1D or whatever note is sent on Ch1/Ch3
+
+# Load buttons — set to the S2 note once identified via debug output.
+# DDJ-SX: ch6 Note 0x46 (Deck A), ch6 Note 0x47 (Deck B)
+LOAD_NOTE = 0x18   # Browse encoder press → Load track into deck
+
+# ---------------------------------------------------------------------------
+# Mixer faders/knobs  (S2: CC on Ch5=left, Ch6=right, absolute 0-127)
+# Maps (S2_status_byte, S2_cc) → (DDJ_channel, DDJ_cc)
+# All sent as 14-bit HiRes (MSB + LSB=0) to match DDJ-SX KnobSliderHiRes type
+# ---------------------------------------------------------------------------
+MIXER_MAP = {
+    # Left channel mixer (Ch5=0xB5 → DDJ ch0)
+    # S2 CCs are numbered bottom-to-top: Fader=0x01, Filter=0x02, Low=0x03, Mid=0x04, High=0x05, Gain=0x06
+    # Left channel mixer (Ch5=0xB5 → DDJ ch0)
+    (0xB5, 0x01): (0, 0x13),  # Left Ch Fader  → DDJ CC13 on ch0
+    (0xB5, 0x03): (0, 0x0F),  # Left EQ Low    → DDJ CC0F on ch0
+    (0xB5, 0x04): (0, 0x0B),  # Left EQ Mid    → DDJ CC0B on ch0
+    (0xB5, 0x05): (0, 0x07),  # Left EQ High   → DDJ CC07 on ch0
+    (0xB5, 0x06): (0, 0x04),  # Left Gain      → DDJ CC04 on ch0
+    # Right channel mixer (Ch6=0xB6 → DDJ ch1)
+    (0xB6, 0x01): (1, 0x13),  # Right Ch Fader → DDJ CC13 on ch1
+    (0xB6, 0x03): (1, 0x0F),  # Right EQ Low   → DDJ CC0F on ch1
+    (0xB6, 0x04): (1, 0x0B),  # Right EQ Mid   → DDJ CC0B on ch1
+    (0xB6, 0x05): (1, 0x07),  # Right EQ High  → DDJ CC07 on ch1
+    (0xB6, 0x06): (1, 0x04),  # Right Gain     → DDJ CC04 on ch1
+    # Global mixer (Ch7=0xB7)
+    (0xB7, 0x01): (6, 0x1F),  # Crossfader     → DDJ CC1F on ch6
+}
+
+# ---------------------------------------------------------------------------
+# Headphone Cue buttons  (S2: Note 0x08 on Ch5=left, Ch6=right)
+# DDJ-SX: Note 0x54 on ch0 (Deck A) / ch1 (Deck B)
+# ---------------------------------------------------------------------------
+HEADPHONE_CUE_CODES = {
+    (0x95, 0x08): 0,  # Left deck headphone cue
+    (0x96, 0x08): 1,  # Right deck headphone cue
+}
+
+# ---------------------------------------------------------------------------
+# FX Select buttons  (S2: Note on Ch7=0x97, global mixer)
+# DDJ-SX: FX Assign buttons on ch6
+#   Layout:  [1] [2]    →  FX1/FX2 for CH1 (top row)
+#            [3] [4]    →  FX1/FX2 for CH2 (bottom row)
+# ---------------------------------------------------------------------------
+FX_SELECT_MAP = {
+    (0x97, 0x04): (4, 0x47),  # FX Select 1 → DDJ FX1-1 On/Off
+    (0x97, 0x05): (4, 0x48),  # FX Select 2 → DDJ FX1-2 On/Off
+    (0x97, 0x02): (4, 0x49),  # FX Select 3 → DDJ FX1-3 On/Off
+    (0x97, 0x03): (4, 0x43),  # FX Select 4 → DDJ FX1 Release FX
+}
+
+# S2 FX button note → active FX slot (1/2/3 or 0 for release/none)
+FX_NOTE_TO_SLOT = {0x04: 1, 0x05: 2, 0x02: 3, 0x03: 0}
+
+# ---------------------------------------------------------------------------
+# FX/Filter knob  (S2: CC 0x02 on Ch5=left, Ch6=right)
+# Routes to active FX slot depth on DDJ FX1 unit (ch4) when an FX is active,
+# falls back to CFX filter (ch6 CC 0x17/0x18) when no FX is selected.
+# DDJ FX depth CCs: FX1-1=0x02, FX1-2=0x04, FX1-3=0x06  (KnobSliderHiRes)
+# ---------------------------------------------------------------------------
+FX_KNOB_CODES = {
+    (0xB5, 0x02): 0,  # Left deck  → FX1 unit (ch4) or CFXParameterCH1
+    (0xB6, 0x02): 1,  # Right deck → FX1 unit (ch4) or CFXParameterCH2
+}
+
+FX_DEPTH_CC = {1: 0x02, 2: 0x04, 3: 0x06}  # FX slot → DDJ FX1 depth CC
+
+# Active FX slot state (updated when FX select buttons are pressed)
+_active_fx = 0  # 0=none, 1=FX1-1, 2=FX1-2, 3=FX1-3
+
+# ---------------------------------------------------------------------------
+# Notes/CCs to silently ignore (known controls with no DDJ-SX equivalent)
+# ---------------------------------------------------------------------------
+IGNORED_NOTES = {0x29, 0x28, 0x27}  # Shift button, Loop encoder touch, Move encoder touch
+
+# ---------------------------------------------------------------------------
+# Loop encoder rotation  (S2: CC 0x1D on Ch1/Ch3, relative, center=64)
+# CW (>64) → LoopDouble (DDJ note 0x13), CCW (<64) → LoopHalf (DDJ note 0x12)
+# ---------------------------------------------------------------------------
+LOOP_ENCODER_CODES = {
+    (0xB1, 0x1D): 0,  # Deck A loop encoder
+    (0xB3, 0x1D): 1,  # Deck B loop encoder
+}
+
+# ---------------------------------------------------------------------------
+# Move encoder rotation  (S2: CC 0x1B on Ch1/Ch3, relative, center=64)
+# CW (>64) → LoopMoveRight (DDJ note 0x62), CCW (<64) → LoopMoveLeft (DDJ note 0x61)
+# ---------------------------------------------------------------------------
+MOVE_ENCODER_CODES = {
+    (0xB1, 0x1B): 0,  # Deck A move encoder
+    (0xB3, 0x1B): 1,  # Deck B move encoder
+}
+
+# ---------------------------------------------------------------------------
+# Shift+Move encoder  (S2: CC 0x1B on Ch2/Ch4, relative, center=64)
+# → DDJ-SX JogSearch (CC 0x1F, Difference type) — scrubs through track
+# Works without active loop, unlike LoopMove.
+# ---------------------------------------------------------------------------
+SHIFT_MOVE_ENCODER_CODES = {
+    (0xB2, 0x1B): 0,  # Deck A shift+move encoder
+    (0xB4, 0x1B): 1,  # Deck B shift+move encoder
+}
+
+IGNORED_CCS = {
+    (0xB2, 0x1D),  # Shift+Loop encoder rotation (Deck A) — no DDJ-SX equivalent
+    (0xB4, 0x1D),  # Shift+Loop encoder rotation (Deck B) — no DDJ-SX equivalent
+}
+
+
+# =============================================================================
+# Helper: deck channel → deck index
+# =============================================================================
+S2_DECK_CHANNELS = {
+    0x91: 0,  # Ch1 Note = Deck A, no shift
+    0x93: 1,  # Ch3 Note = Deck B, no shift
+}
+S2_SHIFT_CHANNELS = {
+    0x92: 0,  # Ch2 Note = Deck A + Shift
+    0x94: 1,  # Ch4 Note = Deck B + Shift
+}
+
+
+# =============================================================================
+# Translation functions
+# =============================================================================
+
+def map_jog_value(midi_value):
+    """Amplify S2 jog relative value for DDJ-SX."""
+    delta = midi_value - 64
+    amplified = 64 + (delta * JOG_AMPLIFY)
+    return max(1, min(127, amplified))
+
+
+def jog(midi_out, msg):
+    deck_id = JOG_CODES[tuple(msg.bytes()[:2])]
+    v = msg.bytes()[2]
+    if v == 64:
+        return
+    v = map_jog_value(v)
+    ms = mido.Message.from_bytes([0xB0 + deck_id, 0x22, v])
+    for _ in range(JOG_MULTIPLIER):
+        midi_out.send(ms)
+
+
+def touch(midi_out, deck_id, on):
+    vel = 0x7F if on else 0x00
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, 0x36, vel]))
+
+
+def tempo(midi_out, deck_id, value):
+    """Send DDJ-SX 14-bit tempo (MSB from S2 value, LSB=0)."""
+    midi_out.send(mido.Message.from_bytes([0xB0 + deck_id, 0x00, value]))
+    midi_out.send(mido.Message.from_bytes([0xB0 + deck_id, 0x20, 0]))
+
+
+def send_button(midi_out, deck_id, note, velocity):
+    """Send a DDJ-SX Note On/Off for a deck button."""
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, note, velocity]))
+
+
+def send_pad(midi_out, deck_id, s2_note, velocity, shifted=False):
+    """Translate S2 pad note to DDJ-SX pad on ch7/ch8."""
+    pad_index = s2_note - PAD_FIRST_NOTE          # 0-7
+    ddj_note = pad_index + (0x08 if shifted else 0x00)
+    ddj_ch = 7 + deck_id                           # ch7=DeckA, ch8=DeckB
+    midi_out.send(mido.Message.from_bytes([0x90 + ddj_ch, ddj_note, velocity]))
+
+
+def send_browse(midi_out, value):
+    """Forward browse encoder to DDJ-SX ch6 CC 0x40."""
+    midi_out.send(mido.Message.from_bytes([0xB6, 0x40, value]))
+
+
+def send_loop_size(midi_out, deck_id, value):
+    """Translate loop encoder rotation to DDJ-SX LoopHalf/LoopDouble press."""
+    if value > 64:
+        ddj_note = 0x13  # LoopDouble (clockwise)
+    elif value < 64:
+        ddj_note = 0x12  # LoopHalf (counter-clockwise)
+    else:
+        return
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, ddj_note, 0x7F]))
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, ddj_note, 0x00]))
+
+
+def send_loop_move(midi_out, deck_id, value):
+    """Translate Move encoder rotation to DDJ-SX LoopMoveLeft/Right press."""
+    if value > 64:
+        ddj_note = 0x62  # LoopMoveRight (clockwise)
+    elif value < 64:
+        ddj_note = 0x61  # LoopMoveLeft (counter-clockwise)
+    else:
+        return
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, ddj_note, 0x7F]))
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, ddj_note, 0x00]))
+
+
+def send_beatjump(midi_out, deck_id, value):
+    """Jump forward/backward using DDJ-SX BeatJump pads (REV4/FWD4).
+    Briefly activates BeatJump pad mode, sends the jump, restores HotCue mode.
+    Default jump size for PAD7/8 in Rekordbox is configurable — set to 8 bars
+    in Rekordbox Preferences > Controller > Pad tab > BeatJump.
+    """
+    if value > 64:
+        pad_note = 0x47  # PAD8_BeatJump = FWD4 (largest forward jump)
+    elif value < 64:
+        pad_note = 0x46  # PAD7_BeatJump = REV4 (largest backward jump)
+    else:
+        return
+    pad_ch = 7 + deck_id  # ch7=DeckA, ch8=DeckB
+    # Activate BeatJump pad mode
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, 0x69, 0x7F]))
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, 0x69, 0x00]))
+    # Send pad press + release
+    midi_out.send(mido.Message.from_bytes([0x90 + pad_ch, pad_note, 0x7F]))
+    midi_out.send(mido.Message.from_bytes([0x90 + pad_ch, pad_note, 0x00]))
+    # Restore HotCue pad mode
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, 0x1B, 0x7F]))
+    midi_out.send(mido.Message.from_bytes([0x90 + deck_id, 0x1B, 0x00]))
+
+
+def send_mixer(midi_out, ddj_ch, ddj_cc, value):
+    """Send DDJ-SX mixer CC as 14-bit HiRes (MSB + LSB=0)."""
+    midi_out.send(mido.Message.from_bytes([0xB0 + ddj_ch, ddj_cc, value]))
+    midi_out.send(mido.Message.from_bytes([0xB0 + ddj_ch, ddj_cc + 0x20, 0]))
+
+
+def send_fx_or_filter(midi_out, deck_id, value):
+    """Route FX/Filter knob to active FX slot depth, or CFX filter when no FX active."""
+    if _active_fx in FX_DEPTH_CC:
+        cc = FX_DEPTH_CC[_active_fx]
+        midi_out.send(mido.Message.from_bytes([0xB4, cc, value]))
+        midi_out.send(mido.Message.from_bytes([0xB4, cc + 0x20, 0]))
+    else:
+        cfx_cc = 0x17 + deck_id  # 0x17=CFXParameterCH1, 0x18=CFXParameterCH2
+        midi_out.send(mido.Message.from_bytes([0xB6, cfx_cc, value]))
+        midi_out.send(mido.Message.from_bytes([0xB6, cfx_cc + 0x20, 0]))
+
+
+# =============================================================================
+# Main loop
+# =============================================================================
+
+def main():
+    global _active_fx
+    try:
+        midi_inp_conf, midi_out_conf = check_config()
+        midi_inp = mido.open_input(midi_inp_conf)
+        if os.name == 'nt':
+            midi_out = mido.open_output(midi_out_conf)
+        else:
+            midi_out = mido.open_output("Pioneer DDJ-SX", True)
+
+        rekordjog_start_sequence()
+        print("Controller: Native Instruments Traktor Kontrol S2 MK3")
+        print("Listening for MIDI messages... (Ctrl+C to quit)")
+        print()
+        print("Debug legend:")
+        print("  [JOG]       Jogwheel rotation")
+        print("  [TOUCH]     Jogwheel touch on/off")
+        print("  [TEMPO]     Pitch/tempo fader")
+        print("  [BTN]       Deck button (mapped)")
+        print("  [SHIFT+BTN] Shift+button (mapped)")
+        print("  [PAD]       Performance pad")
+        print("  [BROWSE]    Browse encoder")
+        print("  [MIXER]     Mixer fader/knob")
+        print("  [HPCUE]     Headphone Cue button")
+        print("  [FX DEP]    FX depth knob (routes to active FX slot or filter)")
+        print("  [???]       Unrecognised — note it and add to mapping")
+        print()
+
+        while True:
+            ims = midi_inp.receive()
+            b = ims.bytes()
+            status = b[0]
+            msg_type = status & 0xF0
+            ch = status & 0x0F      # 0-based channel index
+            data1 = b[1] if len(b) > 1 else None
+            data2 = b[2] if len(b) > 2 else None
+            key2 = (b[0], b[1]) if len(b) >= 2 else None
+            raw = ' '.join(f'0x{x:02X}' for x in b)
+
+            # ---------------------------------------------------------------
+            # Jogwheel rotation
+            # ---------------------------------------------------------------
+            if key2 in JOG_CODES:
+                deck_id = JOG_CODES[key2]
+                print(f"[JOG]    Deck {'A' if deck_id == 0 else 'B'} val={data2}  {raw}")
+                jog(midi_out, ims)
+
+            # ---------------------------------------------------------------
+            # Jogwheel touch
+            # ---------------------------------------------------------------
+            elif key2 in TOUCH_CODES:
+                deck_id = TOUCH_CODES[key2]
+                on = (msg_type == 0x90 and data2 == 0x7F)
+                state = "ON " if on else "OFF"
+                print(f"[TOUCH {state}] Deck {'A' if deck_id == 0 else 'B'}  {raw}")
+                touch(midi_out, deck_id, on)
+
+            # ---------------------------------------------------------------
+            # Tempo fader
+            # ---------------------------------------------------------------
+            elif key2 in TEMPO_CODES:
+                deck_id = TEMPO_CODES[key2]
+                print(f"[TEMPO]  Deck {'A' if deck_id == 0 else 'B'} val={data2}  {raw}")
+                tempo(midi_out, deck_id, data2)
+
+            # ---------------------------------------------------------------
+            # Per-deck buttons (Ch1 = Deck A, Ch3 = Deck B, Note On/Off)
+            # ---------------------------------------------------------------
+            elif status in S2_DECK_CHANNELS and msg_type == 0x90:
+                deck_id = S2_DECK_CHANNELS[status]
+                note = data1
+                vel = data2
+
+                if PAD_FIRST_NOTE <= note <= PAD_LAST_NOTE:
+                    print(f"[PAD]    Deck {'A' if deck_id == 0 else 'B'} pad={(note - PAD_FIRST_NOTE + 1)} vel={vel}  {raw}")
+                    send_pad(midi_out, deck_id, note, vel, shifted=False)
+
+                elif note in DECK_BUTTON_MAP:
+                    ddj_note = DECK_BUTTON_MAP[note]
+                    print(f"[BTN]    Deck {'A' if deck_id == 0 else 'B'} note=0x{note:02X}→0x{ddj_note:02X} vel={vel}  {raw}")
+                    send_button(midi_out, deck_id, ddj_note, vel)
+
+                elif LOAD_NOTE is not None and note == LOAD_NOTE:
+                    # Load button: maps to DDJ ch6 note 0x46/0x47
+                    ddj_load_note = 0x46 + deck_id
+                    print(f"[LOAD]   Deck {'A' if deck_id == 0 else 'B'} vel={vel}  {raw}")
+                    midi_out.send(mido.Message.from_bytes([0x96, ddj_load_note, vel]))
+
+                elif note in IGNORED_NOTES:
+                    pass  # Shift button etc — silently ignore
+
+                else:
+                    print(f"[???]    {raw}  (deck {'A' if deck_id == 0 else 'B'} note=0x{note:02X})")
+
+            # ---------------------------------------------------------------
+            # Shift-layer buttons (Ch2 = A+Shift, Ch4 = B+Shift)
+            # ---------------------------------------------------------------
+            elif status in S2_SHIFT_CHANNELS and msg_type == 0x90:
+                deck_id = S2_SHIFT_CHANNELS[status]
+                note = data1
+                vel = data2
+
+                if PAD_FIRST_NOTE <= note <= PAD_LAST_NOTE:
+                    print(f"[PAD+SH] Deck {'A' if deck_id == 0 else 'B'} pad={(note - PAD_FIRST_NOTE + 1)} vel={vel}  {raw}")
+                    send_pad(midi_out, deck_id, note, vel, shifted=True)
+
+                elif note in SHIFT_BUTTON_MAP:
+                    ddj_note = SHIFT_BUTTON_MAP[note]
+                    print(f"[SHIFT+BTN] Deck {'A' if deck_id == 0 else 'B'} note=0x{note:02X}→0x{ddj_note:02X} vel={vel}  {raw}")
+                    send_button(midi_out, deck_id, ddj_note, vel)
+
+                elif note in IGNORED_NOTES:
+                    pass  # Shift button etc — silently ignore
+
+                else:
+                    print(f"[???]    {raw}  (deck {'A' if deck_id == 0 else 'B'} shift note=0x{note:02X})")
+
+            # ---------------------------------------------------------------
+            # Loop encoder rotation (CC 0x1D on Ch1/Ch3)
+            # ---------------------------------------------------------------
+            elif key2 in LOOP_ENCODER_CODES:
+                deck_id = LOOP_ENCODER_CODES[key2]
+                direction = "CW +size" if data2 > 64 else "CCW -size"
+                print(f"[LOOP]   Deck {'A' if deck_id == 0 else 'B'} val={data2} ({direction})  {raw}")
+                send_loop_size(midi_out, deck_id, data2)
+
+            # ---------------------------------------------------------------
+            # Move encoder rotation (CC 0x1B on Ch1/Ch3) → Loop Move
+            # ---------------------------------------------------------------
+            elif key2 in MOVE_ENCODER_CODES:
+                deck_id = MOVE_ENCODER_CODES[key2]
+                direction = "CW →" if data2 > 64 else "CCW ←"
+                print(f"[MOVE]   Deck {'A' if deck_id == 0 else 'B'} val={data2} ({direction})  {raw}")
+                send_loop_move(midi_out, deck_id, data2)
+
+            # ---------------------------------------------------------------
+            # Shift+Move encoder (CC 0x1B on Ch2/Ch4) → BeatJump
+            # ---------------------------------------------------------------
+            elif key2 in SHIFT_MOVE_ENCODER_CODES:
+                deck_id = SHIFT_MOVE_ENCODER_CODES[key2]
+                direction = "FWD →→" if data2 > 64 else "BWD ←←"
+                print(f"[JUMP]   Deck {'A' if deck_id == 0 else 'B'} val={data2} ({direction})  {raw}")
+                send_beatjump(midi_out, deck_id, data2)
+
+            # ---------------------------------------------------------------
+            # Browse encoder (CC 0x19 on Ch1/Ch3)
+            # ---------------------------------------------------------------
+            elif key2 in BROWSE_CODES:
+                print(f"[BROWSE] val={data2} ({'+1' if data2 > 64 else '-1'})  {raw}")
+                send_browse(midi_out, data2)
+
+            # Browse encoder press (Note — TBD)
+            elif (BROWSE_PRESS_NOTE is not None
+                  and msg_type == 0x90
+                  and data1 == BROWSE_PRESS_NOTE
+                  and status in (0x91, 0x93)):
+                print(f"[BROWSE PRESS] vel={data2}  {raw}")
+                midi_out.send(mido.Message.from_bytes([0x96, 0x41, data2]))
+
+            # ---------------------------------------------------------------
+            # FX/Filter knob (CC 0x02 on Ch5/Ch6 — dynamic routing)
+            # ---------------------------------------------------------------
+            elif key2 in FX_KNOB_CODES:
+                deck_id = FX_KNOB_CODES[key2]
+                target = f"FX{_active_fx} depth" if _active_fx in FX_DEPTH_CC else "filter"
+                print(f"[FX DEP] Deck {'A' if deck_id == 0 else 'B'} val={data2} → {target}  {raw}")
+                send_fx_or_filter(midi_out, deck_id, data2)
+
+            # ---------------------------------------------------------------
+            # Mixer faders/knobs (Ch5, Ch6, Ch7 — CC messages)
+            # ---------------------------------------------------------------
+            elif key2 in MIXER_MAP:
+                ddj_ch, ddj_cc = MIXER_MAP[key2]
+                print(f"[MIXER]  (0x{status:02X} CC0x{data1:02X}) val={data2} "
+                      f"→ DDJ ch{ddj_ch} CC0x{ddj_cc:02X}  {raw}")
+                send_mixer(midi_out, ddj_ch, ddj_cc, data2)
+
+            # ---------------------------------------------------------------
+            # Headphone Cue buttons
+            # ---------------------------------------------------------------
+            elif key2 in HEADPHONE_CUE_CODES:
+                deck_id = HEADPHONE_CUE_CODES[key2]
+                print(f"[HPCUE]  Deck {'A' if deck_id == 0 else 'B'} vel={data2}  {raw}")
+                send_button(midi_out, deck_id, 0x54, data2)
+
+            # ---------------------------------------------------------------
+            # FX Select buttons (Ch7 = 0x97, Note On/Off)
+            # ---------------------------------------------------------------
+            elif key2 in FX_SELECT_MAP:
+                ddj_ch, ddj_note = FX_SELECT_MAP[key2]
+                if data2 > 0:  # Note On → update active FX slot
+                    _active_fx = FX_NOTE_TO_SLOT.get(data1, _active_fx)
+                slot_label = f"slot {_active_fx}" if _active_fx > 0 else "release"
+                print(f"[FX SEL] note=0x{data1:02X} vel={data2} → DDJ ch{ddj_ch} note=0x{ddj_note:02X} ({slot_label})  {raw}")
+                midi_out.send(mido.Message.from_bytes([0x90 + ddj_ch, ddj_note, data2]))
+
+            # ---------------------------------------------------------------
+            # Silently ignored CCs (FLX encoder etc.)
+            # ---------------------------------------------------------------
+            elif key2 in IGNORED_CCS:
+                pass
+
+            # ---------------------------------------------------------------
+            # Unrecognised — print for identification
+            # ---------------------------------------------------------------
+            else:
+                print(f"[???]    {raw}  type={ims.type} ch={ch}")
+
+    except KeyboardInterrupt:
+        print("\nClosing RekordJog, bye.")
+
+
+if __name__ == "__main__":
+    main()

--- a/RekordJog_KontrolS2MK3.py
+++ b/RekordJog_KontrolS2MK3.py
@@ -119,9 +119,9 @@ BROWSE_CODES = {
 # Set to None to disable; set to the S2 note number once identified.
 BROWSE_PRESS_NOTE = None  # e.g. 0x1D or whatever note is sent on Ch1/Ch3
 
-# Load buttons — set to the S2 note once identified via debug output.
+# Load button (S2 browse-encoder press, note 0x18) — identified and confirmed.
 # DDJ-SX: ch6 Note 0x46 (Deck A), ch6 Note 0x47 (Deck B)
-LOAD_NOTE = 0x18   # Browse encoder press → Load track into deck
+LOAD_NOTE = 0x18  # S2 browse-encoder press → Load track into deck
 
 # ---------------------------------------------------------------------------
 # Mixer faders/knobs  (S2: CC on Ch5=left, Ch6=right, absolute 0-127)

--- a/capture_s2mk3_midi.py
+++ b/capture_s2mk3_midi.py
@@ -1,0 +1,235 @@
+#!/usr/bin/env python3
+"""
+S2 MK3 MIDI Capture Tool
+=========================
+Captures MIDI messages from the Kontrol S2 MK3 in MIDI mode
+and outputs them in a format ready to paste into RekordJog_KontrolS2MK3.py.
+
+Usage:
+  1. Put S2 MK3 in MIDI mode (hold left FLX button + connect USB)
+  2. Run: python3 capture_s2mk3_midi.py
+  3. Select the S2 MK3 from the device list
+  4. Follow the on-screen instructions for each control
+  5. Copy the generated output into the main script
+"""
+
+import mido
+import time
+import sys
+
+
+def select_device():
+    """Let user pick the S2 MK3 from available MIDI inputs."""
+    inputs = mido.get_input_names()
+    if not inputs:
+        print("No MIDI input devices found!")
+        print("Is the S2 MK3 connected and in MIDI mode?")
+        print("(Hold left FLX button while connecting USB)")
+        sys.exit(1)
+
+    print("\nAvailable MIDI input devices:")
+    for i, name in enumerate(inputs, 1):
+        print(f"  {i}. {name}")
+
+    choice = int(input("\nSelect device number: ")) - 1
+    return inputs[choice]
+
+
+def capture_messages(port, duration=5, description=""):
+    """Capture MIDI messages for a given duration."""
+    print(f"\n>>> {description}")
+    print(f"    Recording for {duration} seconds... GO!")
+
+    messages = []
+    start = time.time()
+    while time.time() - start < duration:
+        msg = port.poll()
+        if msg is not None:
+            messages.append({
+                'type': msg.type,
+                'bytes': msg.bytes(),
+                'hex': ' '.join(f'0x{b:02X}' for b in msg.bytes()),
+                'time': time.time() - start,
+                'raw': msg,
+            })
+
+    print(f"    Captured {len(messages)} messages.")
+    return messages
+
+
+def print_messages(messages):
+    """Print captured messages in a readable format."""
+    for m in messages:
+        b = m['bytes']
+        status = b[0]
+        ch = status & 0x0F
+        msg_type = status & 0xF0
+
+        type_name = {0x80: 'NoteOff', 0x90: 'NoteOn', 0xB0: 'CC', 0xE0: 'PitchBend'}
+        t = type_name.get(msg_type, f'0x{msg_type:02X}')
+
+        if len(b) >= 3:
+            print(f"    [{m['time']:5.2f}s] {t} ch={ch} "
+                  f"data1=0x{b[1]:02X}({b[1]:3d}) "
+                  f"data2=0x{b[2]:02X}({b[2]:3d})  "
+                  f"raw: {m['hex']}")
+        elif len(b) >= 2:
+            print(f"    [{m['time']:5.2f}s] {t} ch={ch} "
+                  f"data1=0x{b[1]:02X}({b[1]:3d})  "
+                  f"raw: {m['hex']}")
+
+
+def analyze_jog(messages):
+    """Analyze jog messages and extract the mapping pattern."""
+    if not messages:
+        return None, None
+
+    # Group by first 2 bytes (status + data1)
+    codes = {}
+    values = set()
+    for m in messages:
+        b = m['bytes']
+        if len(b) >= 3:
+            key = (b[0], b[1])
+            if key not in codes:
+                codes[key] = []
+            codes[key].append(b[2])
+            values.add(b[2])
+
+    return codes, sorted(values)
+
+
+def main():
+    device = select_device()
+    port = mido.open_input(device)
+
+    print("\n" + "=" * 60)
+    print("  S2 MK3 MIDI Capture")
+    print("=" * 60)
+
+    results = {}
+
+    # --- Left Jogwheel ---
+    input("\nPress ENTER, then SLOWLY rotate LEFT jogwheel CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Left Jog - Slow CW")
+    print_messages(msgs)
+    results['left_jog_cw_slow'] = msgs
+
+    input("\nPress ENTER, then FAST rotate LEFT jogwheel CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Left Jog - Fast CW")
+    print_messages(msgs)
+    results['left_jog_cw_fast'] = msgs
+
+    input("\nPress ENTER, then SLOWLY rotate LEFT jogwheel COUNTER-CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Left Jog - Slow CCW")
+    print_messages(msgs)
+    results['left_jog_ccw_slow'] = msgs
+
+    input("\nPress ENTER, then FAST rotate LEFT jogwheel COUNTER-CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Left Jog - Fast CCW")
+    print_messages(msgs)
+    results['left_jog_ccw_fast'] = msgs
+
+    # --- Right Jogwheel ---
+    input("\nPress ENTER, then SLOWLY rotate RIGHT jogwheel CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Right Jog - Slow CW")
+    print_messages(msgs)
+    results['right_jog_cw_slow'] = msgs
+
+    input("\nPress ENTER, then FAST rotate RIGHT jogwheel CLOCKWISE...")
+    msgs = capture_messages(port, 5, "Right Jog - Fast CW")
+    print_messages(msgs)
+    results['right_jog_cw_fast'] = msgs
+
+    # --- Touch Detection ---
+    input("\nPress ENTER, then TOUCH the LEFT jogwheel surface (don't rotate)...")
+    msgs = capture_messages(port, 3, "Left Jog - Touch On")
+    print_messages(msgs)
+    results['left_touch_on'] = msgs
+
+    input("\nPress ENTER, then LIFT finger from LEFT jogwheel...")
+    msgs = capture_messages(port, 3, "Left Jog - Touch Off")
+    print_messages(msgs)
+    results['left_touch_off'] = msgs
+
+    input("\nPress ENTER, then TOUCH the RIGHT jogwheel surface...")
+    msgs = capture_messages(port, 3, "Right Jog - Touch On")
+    print_messages(msgs)
+    results['right_touch_on'] = msgs
+
+    input("\nPress ENTER, then LIFT finger from RIGHT jogwheel...")
+    msgs = capture_messages(port, 3, "Right Jog - Touch Off")
+    print_messages(msgs)
+    results['right_touch_off'] = msgs
+
+    # --- Tempo Faders ---
+    input("\nPress ENTER, then SLOWLY move LEFT tempo fader full range...")
+    msgs = capture_messages(port, 8, "Left Tempo Fader")
+    print_messages(msgs)
+    results['left_tempo'] = msgs
+
+    input("\nPress ENTER, then SLOWLY move RIGHT tempo fader full range...")
+    msgs = capture_messages(port, 8, "Right Tempo Fader")
+    print_messages(msgs)
+    results['right_tempo'] = msgs
+
+    # --- Summary ---
+    print("\n" + "=" * 60)
+    print("  CAPTURE COMPLETE - SUMMARY")
+    print("=" * 60)
+
+    # Analyze jog codes
+    all_jog_msgs = (
+        results.get('left_jog_cw_slow', []) +
+        results.get('left_jog_cw_fast', []) +
+        results.get('left_jog_ccw_slow', []) +
+        results.get('left_jog_ccw_fast', []) +
+        results.get('right_jog_cw_slow', []) +
+        results.get('right_jog_cw_fast', [])
+    )
+
+    codes, values = analyze_jog(all_jog_msgs)
+    if codes:
+        print("\nJog rotation MIDI codes detected:")
+        for key, vals in codes.items():
+            unique_vals = sorted(set(vals))
+            print(f"  (0x{key[0]:02X}, 0x{key[1]:02X}) -> values: "
+                  f"min={min(unique_vals)}, max={max(unique_vals)}, "
+                  f"unique count={len(unique_vals)}")
+            print(f"    All unique values: {unique_vals}")
+
+    print("\n--- Paste this into RekordJog_KontrolS2MK3.py ---\n")
+
+    if codes:
+        print("JOG_CODES = {")
+        for i, key in enumerate(codes.keys()):
+            print(f"    (0x{key[0]:02X}, 0x{key[1]:02X}): {i},  "
+                  f"# Deck {'A (left)' if i == 0 else 'B (right)'}")
+        print("}")
+
+    # Touch codes
+    for label, key in [("TOUCH_ON", 'left_touch_on'), ("TOUCH_ON", 'right_touch_on')]:
+        msgs = results.get(key, [])
+        if msgs:
+            b = msgs[0]['bytes']
+            print(f"# {label}: (0x{b[0]:02X}, 0x{b[1]:02X})")
+
+    for label, key in [("TOUCH_OFF", 'left_touch_off'), ("TOUCH_OFF", 'right_touch_off')]:
+        msgs = results.get(key, [])
+        if msgs:
+            b = msgs[0]['bytes']
+            print(f"# {label}: (0x{b[0]:02X}, 0x{b[1]:02X})")
+
+    # Tempo codes
+    for label, key in [("TEMPO left", 'left_tempo'), ("TEMPO right", 'right_tempo')]:
+        msgs = results.get(key, [])
+        if msgs:
+            b = msgs[0]['bytes']
+            print(f"# {label}: (0x{b[0]:02X}, 0x{b[1]:02X})")
+
+    print("\nDone! Copy the values above into the main script.")
+    port.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/learn_buttons.py
+++ b/learn_buttons.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""
+S2 MK3 Button-Dump: Zeigt ALLE eingehenden MIDI-Nachrichten an.
+Druecke jeden Button einzeln und notiere die Ausgabe.
+"""
+import mido
+from functions.check_config import check_config
+
+BUTTONS = [
+    "PLAY / PAUSE",
+    "CUE",
+    "SYNC",
+    "REVERSE / SLIP",
+    "KEYLOCK / MASTER",
+    "LOOP SIZE MINUS",
+    "LOOP SIZE PLUS",
+    "AUTO LOOP",
+    "HOT CUE MODE",
+    "SAMPLER MODE",
+    "FLX1",
+    "FLX2",
+    "Taste UNTER FLX1",
+    "Taste UNTER FLX2",
+]
+
+def main():
+    midi_inp_conf, _ = check_config()
+    midi_inp = mido.open_input(midi_inp_conf)
+
+    print("=" * 50)
+    print("  S2 MK3 — Button-Dump")
+    print("=" * 50)
+    print()
+    print("Druecke die Buttons auf der LINKEN Seite (Deck A)")
+    print("in dieser Reihenfolge, EINEN nach dem anderen:")
+    print()
+    for i, name in enumerate(BUTTONS, 1):
+        print(f"  {i:2d}. {name}")
+    print()
+    print("Jeder Knopfdruck erzeugt Ausgabe.")
+    print("Ctrl+C zum Beenden. Dann die Ausgabe hier posten.")
+    print()
+    print("-" * 50)
+    print()
+
+    while True:
+        msg = midi_inp.receive()
+        b = msg.bytes()
+        raw = ' '.join(f'0x{x:02X}' for x in b)
+
+        # Only show Note On with velocity > 0 (skip releases)
+        if len(b) >= 3 and (b[0] & 0xF0) == 0x90 and b[2] > 0:
+            ch = b[0] & 0x0F
+            note = b[1]
+            vel = b[2]
+            print(f"Ch{ch+1}  Note 0x{note:02X}  vel={vel}   [{raw}]")
+
+
+if __name__ == "__main__":
+    main()

--- a/pioneer_mappings/PIONEER DDJ-SX.midi.csv
+++ b/pioneer_mappings/PIONEER DDJ-SX.midi.csv
@@ -1,35 +1,381 @@
-@file,1,PIONEER DDJ-SX,,,,,,,,,,,,
+@file,1,PIONEER DDJ-SX
 #name,function,type,input,deck1,deck2,deck3,deck4,output,deck1,deck2,deck3,deck4,option,comment
 ,,,,,,,,,,,,,,
+# Browser,,,,,,,,,,,,,,
+Browse,Browse,Rotary,B640,,,,,,,,,,,Browse(Track/Folder Select)
+Zoom,Browse+Shift,Rotary,B664,,,,,,,,,,,
+Forward,Browse+Press,Button,9641,,,,,,,,,,,Library Forward (Folder Open)
+Forward,Browse+Press+Shift,Button,9642,,,,,,,,,,,Library Forward (Folder Open)
+Load,Load,Button,,9646,9647,9648,9649,,,,,,,Load to Deck / Instant Double (double click)
+SortBPM,Load1+Shift,Button,9658,,,,,9658,,,,,,Sort by BPM
+SortSONG,Load2+Shift,Button,9659,,,,,9659,,,,,,Sort by SONG
+SortTRACK,Load3+Shift,Button,9660,,,,,9660,,,,,,Sort by TRACK#
+SortARTIST,Load4+Shift,Button,9661,,,,,9661,,,,,,Sort by ARTIST
+Back,Back,Button,9665,,,,,,,,,,,Library Back (Folder Close)
+Area,Back+Shift,Button,9666,,,,,,,,,,,Area (Change panel type from among several types)
+AddToTagList,LoadPrepare,Button,9667,,,,,,,,,,,Tag Track
+RelatedTracks,LoadPrepare+Shift,Button,9668,,,,,,,,,,,Related Track
 ,,,,,,,,,,,,,,
+# Deck,,,,,,,,,,,,,,
+PlayPause,PlayPause,Button,900B,0,1,2,3,900B,0,1,2,3,Fast;Priority=50,Play/Pause
+PlayPause,PlayPause+Shift,Button,9047,0,1,2,3,9047,0,1,2,3,Fast;Priority=50,Play/Pause
+Cue,Cue,Button,900C,0,1,2,3,900C,0,1,2,3,Fast;Priority=50,Cue Set/Play Cue Back
+JumpToTrackStart,Cue+Shift,Button,9048,0,1,2,3,9048,0,1,2,3,Fast;Priority=50,Jump to track start
 ,,,,,,,,,,,,,,
+JogScratch,JogScratch,JogRotate,B022,0,1,2,3,,,,,,RO,Scratch
+JogPitchBend,JogPitchBend,JogRotate,B023,0,1,2,3,,,,,,RO,Pitch Bend
+JogSearch,JogSearch,Difference,B01F,0,1,2,3,,,,,,RO,Search
+JogTouch,JogTouch,JogTouch,9036,0,1,2,3,,,,,,RO,Touch
+JogTouch,JogTouch+Shift,JogTouch,9067,0,1,2,3,,,,,,RO,Touch
 ,,,,,,,,,,,,,,
+WheelPitchBend,WheelPitchBend,JogRotate,B021,0,1,2,3,,,,,,RO,Pitch Bend
+WheelSearch,WheelSearch,JogRotate,B026,0,1,2,3,,,,,,RO,Pitch Bend
 ,,,,,,,,,,,,,,
+TempoSlider,TempoSlider,KnobSliderHiRes,B000,0,1,2,3,,,,,,Fast,Tempo Control
+TempoSlider,TempoSlider+Shift,KnobSliderHiRes,B005,0,1,2,3,,,,,,Fast,Tempo Control
+MasterTempo,KeyLock,Button,901A,0,1,2,3,901A,0,1,2,3,,MasterTempo On/Off
+TempoRange,KeyLock+Shift,Button,9060,0,1,2,3,9060,0,1,2,3,,Tempo Range
+#,KeyLock+LongPress,Button,901C,0,1,2,3,901C,0,1,2,3,,No function assigned here
+NeedleSearch,NeedleSearch,Value,B003,0,1,2,3,,,,,,Max=16383,Needle Search slide(00-7f)
+#,NeedleSearch+Touch,Button,9043,0,1,2,3,,,,,,,Needle Search touch(00/7f)
+NeedleSearch,NeedleSearch+Shift,Value,B028,0,1,2,3,,,,,,Max=16383,Needle Search slide(00-7f)
+#,NeedleSearch+Touch+Shift,Button,9044,0,1,2,3,,,,,,,Needle Search touch(00/7f)
+Deck,DeckSelect,Button,9072,0,1,2,3,,,,,,RO,Select Deck
+#,Deck+Shift,Button,9073,0,1,2,3,,,,,,,
+Sync,Sync,Button,9058,0,1,2,3,9058,0,1,2,3,Blink=600,Sync On/Off
+Master,Sync+Shift,Button,905C,0,1,2,3,905C,0,1,2,3,,Master On/Off
+AutoLoop,AutoLoop,Button,9014,0,1,2,3,9014,0,1,2,3,,Auto Loop On/Off
+ActiveLoop,AutoLoop+Shift,Button,9050,0,1,2,3,9050,0,1,2,3,,Loop Active/Non active
+LoopHalf,LoopHalf,Button,9012,0,1,2,3,9012,0,1,2,3,Fast,Loop Size Select (Half)
+LoopMoveLeft,LoopHalf+Shift,Button,9061,0,1,2,3,9061,0,1,2,3,,Loop Move left
+LoopDouble,LoopDouble,Button,9013,0,1,2,3,9013,0,1,2,3,Fast,Loop Size Select (Double)
+LoopMoveRight,LoopDouble+Shift,Button,9062,0,1,2,3,9062,0,1,2,3,,Loop Move right
+LoopIn,LoopIn,Button,9010,0,1,2,3,9010,0,1,2,3,Fast,Loop in/Loop in adjust
+ReTrigger,LoopIn+Shift,Button,904C,0,1,2,3,904C,0,1,2,3,Fast,RE-TRIGGER
+LoopOut,LoopOut,Button,9011,0,1,2,3,9011,0,1,2,3,Fast,Loop out/Loop out adjust
+ReloopExit,LoopOut+Shift,Button,904D,0,1,2,3,904D,0,1,2,3,Fast,Reloop/Exit
+SlipReverse,Censor,Button,9015,0,1,2,3,9015,0,1,2,3,Fast,SLIP Reverse
+Reverse,Censor+Shift,Button,9038,0,1,2,3,9038,0,1,2,3,Fast,Reverse
+TempoDown,TempoDown,Indicator,,,,,,9037,0,1,2,3,,indicator for Tempo down
+TempoUp,TempoUp,Indicator,,,,,,9034,0,1,2,3,,indicator for Tempo up
+Slip,Slip,Button,9040,0,1,2,3,9040,0,1,2,3,,SLIP mode On/Off
+Slip,Slip+Shift,Button,9063,0,1,2,3,9063,0,1,2,3,,SLIP mode On/Off
+Vinyl,Vinyl,Button,9017,0,1,2,3,900D,0,1,2,3,,Vinyl Mode On/Off (for JOG)
+GridAdjust,GridAdjust,Button,9079,0,1,2,3,9079,0,1,2,3,,Beat Grid Adjust
+GridAdjustHalf,GridAdjust+Shift,Button,9064,0,1,2,3,9064,0,1,2,3,,Beat Adjust 1/2x
+GridSlide,GridSlide,Button,900A,0,1,2,3,900A,0,1,2,3,,Beat Grid Slide
+GridAdjustDouble,GridSlide+Shift,Button,9065,0,1,2,3,9065,0,1,2,3,,Beat Adjust 2x
+Shift,Shift,Button,903F,,,,,,,,,,RO,Shift
+Shift,Shift,Button,913F,,,,,,,,,,RO,Shift
+Shift,Shift,Button,923F,,,,,,,,,,RO,Shift
+Shift,Shift,Button,933F,,,,,,,,,,RO,Shift
 ,,,,,,,,,,,,,,
+# Mixer,,,,,,,,,,,,,,
+CrossFader,CrossFader,KnobSliderHiRes,B61F,,,,,,,,,,Fast,Crossfader
+ChannelFader,ChannelFader,KnobSliderHiRes,B013,0,1,2,3,,,,,,,CH Fader
+ChannelFaderStartPlay,ChannelFaderStartPlay,Button,9066,0,1,2,3,,,,,,RO,CH Fader Start (PLAY)
+#ChannelFaderStartSync,ChannelFaderStartSync,Button,9051,0,1,2,3,,,,,,RO,CH Fader Start (SYNC)
+ChannelFaderStartCue,ChannelFaderStartCue,Button,9052,0,1,2,3,,,,,,RO,CH Fader Start (CUE)
+Gain,Gain,KnobSliderHiRes,B004,0,1,2,3,,,,,,Fast,Gain
+EQHigh,EQHigh,KnobSliderHiRes,B007,0,1,2,3,,,,,,Fast,EQ High
+EQMid,EQMid,KnobSliderHiRes,B00B,0,1,2,3,,,,,,Fast,EQ Mid
+EQLow,EQLow,KnobSliderHiRes,B00F,0,1,2,3,,,,,,Fast,EQ Low
+HeadphoneCue,HeadphoneCue,Button,9054,0,1,2,3,9054,0,1,2,3,,Headphone CUE On/Off
+TapBpm,HeadphoneCue+Shift,Button,9068,0,1,2,3,9068,0,1,2,3,,TAP BPM
+MasterCue,MasterCue,Button,9663,,,,,,,,,,,Master CUE (All Headphone CUE valid/invalid) (no output)
+SamplerCue,MasterCue+Shift,Button,9662,,,,,9662,,,,,,Headphone CUE On/Off
+CrossfaderAssign.A,CrossfaderAssign.A,Button,9016,0,1,2,3,,,,,,,C.F.assign to deck Left
+CrossfaderAssign.Thru,CrossfaderAssign.Thru,Button,901D,0,1,2,3,,,,,,,Through Crossfader
+CrossfaderAssign.B,CrossfaderAssign.B,Button,9018,0,1,2,3,,,,,,,C.F.assign to deck Right
+ChannelLevel,ChannelLevel,Indicator,,,,,,B002,0,1,2,3,RO;Priority=50,CH Level Indicator
+CrossFaderCurve,CrossFaderCurve,KnobSliderHiRes,B601,,,,,,,,,,,Crossfader curve adjustment
+InputSelect,InputSelect,Button,9019,0,1,2,3,,,,,,,Select INPUT to PC/PHONO/LINE
 ,,,,,,,,,,,,,,
+# Effect,,,,,,,,,,,,,,
+FX1-1,FX1-1,KnobSliderHiRes,B402,,,,,,,,,,,FX1-1 Effect Depth
+FX1-1,FX1-1+Shift,KnobSliderHiRes,B412,,,,,,,,,,,FX1-1 Effect Depth
+FX1-1On,FX1-1On,Button,9447,,,,,9447,,,,,,FX1-1 Effect On/Off
+FX1-1Select,FX1-1On+Shift,Button,9463,,,,,9463,,,,,,FX select
 ,,,,,,,,,,,,,,
+FX1-2,FX1-2,KnobSliderHiRes,B404,,,,,,,,,,,FX1-2 Effect Depth
+FX1-2,FX1-2+Shift,KnobSliderHiRes,B414,,,,,,,,,,,FX1-2 Effect Depth
+FX1-2On,FX1-2On,Button,9448,,,,,9448,,,,,,FX1-2 Effect On/Off
+FX1-2Select,FX1-2On+Shift,Button,9464,,,,,9464,,,,,,FX select/No function when single mode
 ,,,,,,,,,,,,,,
+FX1-3,FX1-3,KnobSliderHiRes,B406,,,,,,,,,,,FX1-3 Effect Depth
+FX1-3,FX1-3+Shift,KnobSliderHiRes,B416,,,,,,,,,,,FX1-3 Effect Depth
+FX1-3On,FX1-3On,Button,9449,,,,,9449,,,,,,FX1-3 Effect On/Off
+FX1-3Select,FX1-3On+Shift,Button,9465,,,,,9465,,,,,,FX select/No function when single mode
 ,,,,,,,,,,,,,,
+FX1BeatUpDown,FX1Beat,Rotary,B400,,,,,,,,,,,FX1 Effect beat down/up
+FX1ReleaseFXType,FX1Beat+Shift,Rotary,B410,,,,,,,,,,,Select FX1 RELEASE FX type
+FX1ReleaseFXOn,FX1Beat+Press,Button,9443,,,,,,,,,,,FX1 RELEASE FX On
+FX1ReleaseFXOn,FX1Beat+Press+Shift,Button,9440,,,,,,,,,,,FX1 RELEASE FX On
+FX1TapBeatWithLongPress,FX1Tap,Button,944A,,,,,944A,,,,,,FX1 Effect tap beat
+FX1FXMode,FX1Tap+Shift,Button,9466,,,,,9466,,,,,,Select FX1 FX mode
 ,,,,,,,,,,,,,,
+FX2-1,FX2-1,KnobSliderHiRes,B502,,,,,,,,,,,FX2-1 Effect Depth
+FX2-1,FX2-1+Shift,KnobSliderHiRes,B512,,,,,,,,,,,FX2-1 Effect Depth
+FX2-1On,FX2-1On,Button,9547,,,,,9547,,,,,,FX2-1 Effect On/Off
+FX2-1Select,FX2-1On+Shift,Button,9563,,,,,9563,,,,,,FX select
 ,,,,,,,,,,,,,,
+FX2-2,FX2-2,KnobSliderHiRes,B504,,,,,,,,,,,FX2-2 Effect Depth
+FX2-2,FX2-2+Shift,KnobSliderHiRes,B514,,,,,,,,,,,FX2-2 Effect Depth
+FX2-2On,FX2-2On,Button,9548,,,,,9548,,,,,,FX2-2 Effect On/Off
+FX2-2Select,FX2-2On+Shift,Button,9564,,,,,9564,,,,,,FX select/No function when single mode
 ,,,,,,,,,,,,,,
+FX2-3,FX2-3,KnobSliderHiRes,B506,,,,,,,,,,,FX2-3 Effect Depth
+FX2-3,FX2-3+Shift,KnobSliderHiRes,B516,,,,,,,,,,,FX2-3 Effect Depth
+FX2-3On,FX2-3On,Button,9549,,,,,9549,,,,,,FX2-3 Effect On/Off
+FX2-3Select,FX2-3On+Shift,Button,9565,,,,,9565,,,,,,FX select/No function when single mode
 ,,,,,,,,,,,,,,
+FX2BeatUpDown,FX2Beat,Rotary,B500,,,,,,,,,,,FX2 Effect beat down/up
+FX2ReleaseFXType,FX2Beat+Shift,Rotary,B510,,,,,,,,,,,Select FX2 RELEASE FX type
+FX2ReleaseFXOn,FX2Beat+Press,Button,9543,,,,,,,,,,,FX2 RELEASE FX On
+FX2ReleaseFXOn,FX2Beat+Press+Shift,Button,9540,,,,,,,,,,,FX2 RELEASE FX On
+FX2TapBeatWithLongPress,FX2Tap,Button,954A,,,,,954A,,,,,,FX2 Effect tap beat
+FX2FXMode,FX2Tap+Shift,Button,9566,,,,,9566,,,,,,Select FX2 FX mode
 ,,,,,,,,,,,,,,
+FX1Assign1,FX1Assign1,Button,964C,,,,,964C,,,,,,FX1 On/Off
+FX1Assign1,FX1Assign1+Shift,Button,9670,,,,,9670,,,,,,FX1 On/Off
+FX2Assign1,FX2Assign1,Button,9650,,,,,9650,,,,,,FX2 On/Off
+FX2Assign1,FX2Assign1+Shift,Button,9654,,,,,9654,,,,,,FX2 On/Off
 ,,,,,,,,,,,,,,
+FX1Assign2,FX1Assign2,Button,964D,,,,,964D,,,,,,FX1 On/Off
+FX1Assign2,FX1Assign2+Shift,Button,9671,,,,,9671,,,,,,FX1 On/Off
+FX2Assign2,FX2Assign2,Button,9651,,,,,9651,,,,,,FX2 On/Off
+FX2Assign2,FX2Assign2+Shift,Button,9655,,,,,9655,,,,,,FX2 On/Off
 ,,,,,,,,,,,,,,
+FX1Assign3,FX1Assign3,Button,964E,,,,,964E,,,,,,FX1 On/Off
+FX1Assign3,FX1Assign3+Shift,Button,9672,,,,,9672,,,,,,FX1 On/Off
+FX2Assign3,FX2Assign3,Button,9652,,,,,9652,,,,,,FX2 On/Off
+FX2Assign3,FX2Assign3+Shift,Button,9656,,,,,9656,,,,,,FX2 On/Off
 ,,,,,,,,,,,,,,
+FX1Assign4,FX1Assign4,Button,964F,,,,,964F,,,,,,FX1 On/Off
+FX1Assign4,FX1Assign4+Shift,Button,9673,,,,,9673,,,,,,FX1 On/Off
+FX2Assign4,FX2Assign4,Button,9653,,,,,9653,,,,,,FX2 On/Off
+FX2Assign4,FX2Assign4+Shift,Button,9657,,,,,9657,,,,,,FX2 On/Off
 ,,,,,,,,,,,,,,
+CFXParameterCH1,CFXParameterCH1,KnobSliderHiRes,B617,,,,,,,,,,Fast,CH1 CFX Depth
+CFXParameterCH1Center,CFXParameterCH1Center,Button,9674,,,,,,,,,,Fast,CH1 CFX Depth
+CFXParameterCH2,CFXParameterCH2,KnobSliderHiRes,B618,,,,,,,,,,Fast,CH2 CFX Depth
+CFXParameterCH2Center,CFXParameterCH2Center,Button,9675,,,,,,,,,,Fast,CH2 CFX Depth
+CFXParameterCH3,CFXParameterCH3,KnobSliderHiRes,B619,,,,,,,,,,Fast,CH3 CFX Depth
+CFXParameterCH3Center,CFXParameterCH3Center,Button,9676,,,,,,,,,,Fast,CH3 CFX Depth
+CFXParameterCH4,CFXParameterCH4,KnobSliderHiRes,B61A,,,,,,,,,,Fast,CH4 CFX Depth
+CFXParameterCH4Center,CFXParameterCH4Center,Button,9677,,,,,,,,,,Fast,CH4 CFX Depth
 ,,,,,,,,,,,,,,
+# Performance,,,,,,,,,,,,,,
+PAD1_HotCue,PAD1.HotCue.Call,Pad,9000,7,8,9,10,9000,7,8,9,10,Fast,HOT CUE1
+PAD1_HotCue+Shift,PAD1.HotCue.Delete,Pad,9008,7,8,9,10,9008,7,8,9,10,Fast,Delete HOT CUE1
+PAD1_PadFx1,PAD1.PadFx1,Pad,9010,7,8,9,10,9010,7,8,9,10,Fast,PAD FX1 Slot1 (momentary)
+PAD1_PadFx1+Shift,,Pad,9018,7,8,9,10,9018,7,8,9,10,Fast,PAD FX1 Slot1 (momentary)
+PAD1_Slicer,PAD1.Slicer,Pad,9020,7,8,9,10,9020,7,8,9,10,Fast,SLICER 1 Play
+PAD1_Slicer+Shift,,Pad,9028,7,8,9,10,9028,7,8,9,10,Fast,No function assigned here
+PAD1_Sampler,PAD1.Sampler.Start,Pad,9030,7,8,9,10,9030,7,8,9,10,Fast,Sample Slot 1 play
+PAD1_Sampler+Shift,PAD1.Sampler.Stop,Pad,9038,7,8,9,10,9038,7,8,9,10,Fast,Sample Slot 1 stop
+PAD1_BeatJump,PAD1.BeatJump,Pad,9040,7,8,9,10,9040,7,8,9,10,Fast,BEAT JUMP (REV1)
+PAD1_BeatJump+Shift,,Pad,9048,7,8,9,10,9048,7,8,9,10,Fast,BEAT JUMP (REV1)
+PAD1_PadFx2,PAD1.PadFx2,Pad,9050,7,8,9,10,9050,7,8,9,10,Fast,PAD FX2 Slot1 (momentary)
+PAD1_PadFx2+Shift,,Pad,9058,7,8,9,10,9058,7,8,9,10,Fast,PAD FX2 Slot1 (momentary)
+PAD1_SlicerLoop,PAD1.SlicerLoop,Pad,9060,7,8,9,10,9060,7,8,9,10,Fast,SLICER LOOP
+PAD1_SlicerLoop+Shift,,Pad,9068,7,8,9,10,9068,7,8,9,10,Fast,No function assigned here
+PAD1_VelocitySampler,PAD1.VelocitySampler.Start,Pad,9070,7,8,9,10,9070,7,8,9,10,Fast,Sample Slot1 Play
+PAD1_VelocitySampler+Velocity,PAD1.VelocitySampler.Level,Value,B030,7,8,9,10,,,,,,Fast,Sample Slot 1 Level (use Pad velocity)
+PAD1_VelocitySampler+Shift,PAD1.VelocitySampler.Stop,Pad,9078,7,8,9,10,9078,7,8,9,10,Fast,Sample Slot 1 stop
 ,,,,,,,,,,,,,,
+PAD2_HotCue,PAD2.HotCue.Call,Pad,9001,7,8,9,10,9001,7,8,9,10,Fast,HOT CUE2
+PAD2_HotCue+Shift,PAD2.HotCue.Delete,Pad,9009,7,8,9,10,9009,7,8,9,10,Fast,Delete HOT CUE2
+PAD2_PadFx1,PAD2.PadFx1,Pad,9011,7,8,9,10,9011,7,8,9,10,Fast,PAD FX1 Slot2 (momentary)
+PAD2_PadFx1+Shift,,Pad,9019,7,8,9,10,9019,7,8,9,10,Fast,PAD FX1 Slot2 (momentary)
+PAD2_Slicer,PAD2.Slicer,Pad,9021,7,8,9,10,9021,7,8,9,10,Fast,SLICER 2 Play
+PAD2_Slicer+Shift,,Pad,9029,7,8,9,10,9029,7,8,9,10,Fast,No function assigned here
+PAD2_Sampler,PAD2.Sampler.Start,Pad,9031,7,8,9,10,9031,7,8,9,10,Fast,Sample Slot2 play
+PAD2_Sampler+Shift,PAD2.Sampler.Stop,Pad,9039,7,8,9,10,9039,7,8,9,10,Fast,Sample Slot2 stop
+PAD2_BeatJump,PAD2.BeatJump,Pad,9041,7,8,9,10,9041,7,8,9,10,Fast,BEAT JUMP (FWD1)
+PAD2_BeatJump+Shift,,Pad,9049,7,8,9,10,9049,7,8,9,10,Fast,BEAT JUMP (FWD1)
+PAD2_PadFx2,PAD2.PadFx2,Pad,9051,7,8,9,10,9051,7,8,9,10,Fast,PAD FX2 Slot2 (momentary)
+PAD2_PadFx2+Shift,,Pad,9059,7,8,9,10,9059,7,8,9,10,Fast,PAD FX2 Slot2 (momentary)
+PAD2_SlicerLoop,PAD2.SlicerLoop,Pad,9061,7,8,9,10,9061,7,8,9,10,Fast,SLICER LOOP
+PAD2_SlicerLoop+Shift,,Pad,9069,7,8,9,10,9069,7,8,9,10,Fast,No function assigned here
+PAD2_VelocitySampler,PAD2.VelocitySampler.Start,Pad,9071,7,8,9,10,9071,7,8,9,10,Fast,Sample Slot2 Play
+PAD2_VelocitySampler+Velocity,PAD2.VelocitySampler.Level,Value,B031,7,8,9,10,,,,,,Fast,Sample Slot 2 Level (use Pad velocity)
+PAD2_VelocitySampler+Shift,PAD2.VelocitySampler.Stop,Pad,9079,7,8,9,10,9079,7,8,9,10,Fast,Sample Slot 2 stop
 ,,,,,,,,,,,,,,
-JogScratch,JogScratch,JogRotate,B00A,1,2,,,,,,,,RO,Scratch
+PAD3_HotCue,PAD3.HotCue.Call,Pad,9002,7,8,9,10,9002,7,8,9,10,Fast,HOT CUE3
+PAD3_HotCue+Shift,PAD3.HotCue.Delete,Pad,900A,7,8,9,10,900A,7,8,9,10,Fast,Delete HOT CUE3
+PAD3_PadFx1,PAD3.PadFx1,Pad,9012,7,8,9,10,9012,7,8,9,10,Fast,PAD FX1 Slot3 (momentary)
+PAD3_PadFx1+Shift,,Pad,901A,7,8,9,10,901A,7,8,9,10,Fast,PAD FX1 Slot3 (momentary)
+PAD3_Slicer,PAD3.Slicer,Pad,9022,7,8,9,10,9022,7,8,9,10,Fast,SLICER 3 Play
+PAD3_Slicer+Shift,,Pad,902A,7,8,9,10,902A,7,8,9,10,Fast,No function assigned here
+PAD3_Sampler,PAD3.Sampler.Start,Pad,9032,7,8,9,10,9032,7,8,9,10,Fast,Sample Slot 3 play
+PAD3_Sampler+Shift,PAD3.Sampler.Stop,Pad,903A,7,8,9,10,903A,7,8,9,10,Fast,Sample Slot 3 stop
+PAD3_BeatJump,PAD3.BeatJump,Pad,9042,7,8,9,10,9042,7,8,9,10,Fast,BEAT JUMP (REV2)
+PAD3_BeatJump+Shift,,Pad,904A,7,8,9,10,904A,7,8,9,10,Fast,BEAT JUMP (REV2)
+PAD3_PadFx2,PAD3.PadFx2,Pad,9052,7,8,9,10,9052,7,8,9,10,Fast,PAD FX2 Slot3 (momentary)
+PAD3_PadFx2+Shift,,Pad,905A,7,8,9,10,905A,7,8,9,10,Fast,PAD FX2 Slot3 (momentary)
+PAD3_SlicerLoop,PAD3.SlicerLoop,Pad,9062,7,8,9,10,9062,7,8,9,10,Fast,SLICER LOOP
+PAD3_SlicerLoop+Shift,,Pad,906A,7,8,9,10,906A,7,8,9,10,Fast,No function assigned here
+PAD3_VelocitySampler,PAD3.VelocitySampler.Start,Pad,9072,7,8,9,10,9072,7,8,9,10,Fast,Sample Slot3 Play
+PAD3_VelocitySampler+Velocity,PAD3.VelocitySampler.Level,Value,B032,7,8,9,10,,,,,,Fast,Sample Slot 3 Level (use Pad velocity)
+PAD3_VelocitySampler+Shift,PAD3.VelocitySampler.Stop,Pad,907A,7,8,9,10,907A,7,8,9,10,Fast,Sample Slot 3 stop
 ,,,,,,,,,,,,,,
-JogSearch,JogSearch,Difference,B00A,4,5,,,,,,,,RO,Search
-JogTouch,JogTouch,JogTouch,9008,1,2,,,,,,,,RO,Touch
-JogTouch,JogTouch+Shift,JogTouch,9008,4,5,,,,,,,,RO,Touch
+PAD4_HotCue,PAD4.HotCue.Call,Pad,9003,7,8,9,10,9003,7,8,9,10,Fast,HOT CUE 4
+PAD4_HotCue+Shift,PAD4.HotCue.Delete,Pad,900B,7,8,9,10,900B,7,8,9,10,Fast,Delete HOT CUE 4
+PAD4_PadFx1,PAD4.PadFx1,Pad,9013,7,8,9,10,9013,7,8,9,10,Fast,PAD FX1 Slot4 (momentary)
+PAD4_PadFx1+Shift,,Pad,901B,7,8,9,10,901B,7,8,9,10,Fast,PAD FX1 Slot4 (momentary)
+PAD4_Slicer,PAD4.Slicer,Pad,9023,7,8,9,10,9023,7,8,9,10,Fast,SLICER 4 Play
+PAD4_Slicer+Shift,,Pad,902B,7,8,9,10,902B,7,8,9,10,Fast,No function assigned here
+PAD4_Sampler,PAD4.Sampler.Start,Pad,9033,7,8,9,10,9033,7,8,9,10,Fast,Sample Slot 4 play
+PAD4_Sampler+Shift,PAD4.Sampler.Stop,Pad,903B,7,8,9,10,903B,7,8,9,10,Fast,Sample Slot 4 stop
+PAD4_BeatJump,PAD4.BeatJump,Pad,9043,7,8,9,10,9043,7,8,9,10,Fast,BEAT JUMP (FWD2)
+PAD4_BeatJump+Shift,,Pad,904B,7,8,9,10,904B,7,8,9,10,Fast,BEAT JUMP (FWD2)
+PAD4_PadFx2,PAD4.PadFx2,Pad,9053,7,8,9,10,9053,7,8,9,10,Fast,PAD FX2 Slot4 (momentary)
+PAD4_PadFx2+Shift,,Pad,905B,7,8,9,10,905B,7,8,9,10,Fast,PAD FX2 Slot4 (momentary)
+PAD4_SlicerLoop,PAD4.SlicerLoop,Pad,9063,7,8,9,10,9063,7,8,9,10,Fast,SLICER LOOP
+PAD4_SlicerLoop+Shift,,Pad,906B,7,8,9,10,906B,7,8,9,10,Fast,No function assigned here
+PAD4_VelocitySampler,PAD4.VelocitySampler.Start,Pad,9073,7,8,9,10,9073,7,8,9,10,Fast,Sample Slot4 Play
+PAD4_VelocitySampler+Velocity,PAD4.VelocitySampler.Level,Value,B033,7,8,9,10,,,,,,Fast,Sample Slot 4 Level (use Pad velocity)
+PAD4_VelocitySampler+Shift,PAD4.VelocitySampler.Stop,Pad,907B,7,8,9,10,907B,7,8,9,10,Fast,Sample Slot 4 stop
 ,,,,,,,,,,,,,,
-WheelPitchBend,WheelPitchBend,JogRotate,B009,1,2,,,,,,,,RO,Pitch Bend
-WheelSearch,WheelSearch,JogRotate,B009,4,5,,,,,,,,RO,Pitch Bend
+PAD5_HotCue,PAD5.HotCue.Call,Pad,9004,7,8,9,10,9004,7,8,9,10,Fast,HOT CUE 5
+PAD5_HotCue+Shift,PAD5.HotCue.Delete,Pad,900C,7,8,9,10,900C,7,8,9,10,Fast,Delete HOT CUE 5
+PAD5_PadFx1,PAD5.PadFx1,Pad,9014,7,8,9,10,9014,7,8,9,10,Fast,PAD FX1 Slot5 (momentary)
+PAD5_PadFx1+Shift,,Pad,901C,7,8,9,10,901C,7,8,9,10,Fast,PAD FX1 Slot5 (momentary)
+PAD5_Slicer,PAD5.Slicer,Pad,9024,7,8,9,10,9024,7,8,9,10,Fast,SLICER 5 Play
+PAD5_Slicer+Shift,PAD5.Slicer.ShiftRangeLeft,Pad,902C,7,8,9,10,902C,7,8,9,10,Fast,DOMAIN MOVE (Left)
+PAD5_Sampler,PAD5.Sampler.Start,Pad,9034,7,8,9,10,9034,7,8,9,10,Fast,Sample Slot 5 play
+PAD5_Sampler+Shift,PAD5.Sampler.Stop,Pad,903C,7,8,9,10,903C,7,8,9,10,Fast,Sample Slot 5 stop
+PAD5_BeatJump,PAD5.BeatJump,Pad,9044,7,8,9,10,9044,7,8,9,10,Fast,BEAT JUMP (REV3)
+PAD5_BeatJump+Shift,,Pad,904C,7,8,9,10,904C,7,8,9,10,Fast,BEAT JUMP (REV3)
+PAD5_PadFx2,PAD5.PadFx2,Pad,9054,7,8,9,10,9054,7,8,9,10,Fast,PAD FX2 Slot5 (momentary)
+PAD5_PadFx2+Shift,,Pad,905C,7,8,9,10,905C,7,8,9,10,Fast,PAD FX2 Slot5 (momentary)
+PAD5_SlicerLoop,PAD5.SlicerLoop,Pad,9064,7,8,9,10,9064,7,8,9,10,Fast,SLICER LOOP
+PAD5_SlicerLoop+Shift,,Pad,906C,7,8,9,10,906C,7,8,9,10,Fast,No function assigned here
+PAD5_VelocitySampler,PAD5.VelocitySampler.Start,Pad,9074,7,8,9,10,9074,7,8,9,10,Fast,Sample Slot5 Play
+PAD5_VelocitySampler+Velocity,PAD5.VelocitySampler.Level,Value,B034,7,8,9,10,,,,,,Fast,Sample Slot 5 Level (use Pad velocity)
+PAD5_VelocitySampler+Shift,PAD5.VelocitySampler.Stop,Pad,907C,7,8,9,10,907C,7,8,9,10,Fast,Sample Slot 5 stop
 ,,,,,,,,,,,,,,
-TempoSlider,TempoSlider,KnobSlider,B070,1,2,,,,,,,,Fast,Tempo Control
-TempoSlider,TempoSlider+Shift,KnobSlider,B070,4,5,,,,,,,,Fast,Tempo Control
+PAD6_HotCue,PAD6.HotCue.Call,Pad,9005,7,8,9,10,9005,7,8,9,10,Fast,HOT CUE 6
+PAD6_HotCue+Shift,PAD6.HotCue.Delete,Pad,900D,7,8,9,10,900D,7,8,9,10,Fast,Delete HOT CUE 6
+PAD6_PadFx1,PAD6.PadFx1,Pad,9015,7,8,9,10,9015,7,8,9,10,Fast,PAD FX1 Slot6 (momentary)
+PAD6_PadFx1+Shift,,Pad,901D,7,8,9,10,901D,7,8,9,10,Fast,PAD FX1 Slot6 (momentary)
+PAD6_Slicer,PAD6.Slicer,Pad,9025,7,8,9,10,9025,7,8,9,10,Fast,SLICER 6 Play
+PAD6_Slicer+Shift,PAD5.Slicer.ShiftRangeRight,Pad,902D,7,8,9,10,902D,7,8,9,10,Fast,DOMAIN MOVE (Right)
+PAD6_Sampler,PAD6.Sampler.Start,Pad,9035,7,8,9,10,9035,7,8,9,10,Fast,Sample Slot 6 play
+PAD6_Sampler+Shift,PAD6.Sampler.Stop,Pad,903D,7,8,9,10,903D,7,8,9,10,Fast,Sample Slot 6 stop
+PAD6_BeatJump,PAD6.BeatJump,Pad,9045,7,8,9,10,9045,7,8,9,10,Fast,BEAT JUMP (FWD3)
+PAD6_BeatJump+Shift,,Pad,904D,7,8,9,10,904D,7,8,9,10,Fast,BEAT JUMP (FWD3)
+PAD6_PadFx2,PAD6.PadFx2,Pad,9055,7,8,9,10,9055,7,8,9,10,Fast,PAD FX2 Slot6 (momentary)
+PAD6_PadFx2+Shift,,Pad,905D,7,8,9,10,905D,7,8,9,10,Fast,PAD FX2 Slot6 (momentary)
+PAD6_SlicerLoop,PAD6.SlicerLoop,Pad,9065,7,8,9,10,9065,7,8,9,10,Fast,SLICER LOOP
+PAD6_SlicerLoop+Shift,,Pad,906D,7,8,9,10,906D,7,8,9,10,Fast,No function assigned here
+PAD6_VelocitySampler,PAD6.VelocitySampler.Start,Pad,9075,7,8,9,10,9075,7,8,9,10,Fast,Sample Slot6 Play
+PAD6_VelocitySampler+Velocity,PAD6.VelocitySampler.Level,Value,B035,7,8,9,10,,,,,,Fast,Sample Slot 6 Level (use Pad velocity)
+PAD6_VelocitySampler+Shift,PAD6.VelocitySampler.Stop,Pad,907D,7,8,9,10,907D,7,8,9,10,Fast,Sample Slot 6 stop
+,,,,,,,,,,,,,,
+PAD7_HotCue,PAD7.HotCue.Call,Pad,9006,7,8,9,10,9006,7,8,9,10,Fast,HOT CUE 7
+PAD7_HotCue+Shift,PAD7.HotCue.Delete,Pad,900E,7,8,9,10,900E,7,8,9,10,Fast,Delete HOT CUE 7
+PAD7_PadFx1,PAD7.PadFx1,Pad,9016,7,8,9,10,9016,7,8,9,10,Fast,PAD FX1 Slot7 (momentary)
+PAD7_PadFx1+Shift,,Pad,901E,7,8,9,10,901E,7,8,9,10,Fast,PAD FX1 Slot7 (momentary)
+PAD7_Slicer,PAD7.Slicer,Pad,9026,7,8,9,10,9026,7,8,9,10,Fast,SLICER 7 Play
+PAD7_Slicer+Shift,,Pad,902E,7,8,9,10,902E,7,8,9,10,Fast,No function assigned here
+PAD7_Sampler,PAD7.Sampler.Start,Pad,9036,7,8,9,10,9036,7,8,9,10,Fast,Sample Slot 7 play
+PAD7_Sampler+Shift,PAD7.Sampler.Stop,Pad,903E,7,8,9,10,903E,7,8,9,10,Fast,Sample Slot 7 stop
+PAD7_BeatJump,PAD7.BeatJump,Pad,9046,7,8,9,10,9046,7,8,9,10,Fast,BEAT JUMP (REV4)
+PAD7_BeatJump+Shift,,Pad,904E,7,8,9,10,904E,7,8,9,10,Fast,BEAT JUMP (REV4)
+PAD7_PadFx2,PAD7.PadFx2,Pad,9056,7,8,9,10,9056,7,8,9,10,Fast,PAD FX2 Slot7 (momentary)
+PAD7_PadFx2+Shift,,Pad,905E,7,8,9,10,905E,7,8,9,10,Fast,PAD FX2 Slot7 (momentary)
+PAD7_SlicerLoop,PAD7.SlicerLoop,Pad,9066,7,8,9,10,9066,7,8,9,10,Fast,SLICER LOOP
+PAD7_SlicerLoop+Shift,,Pad,906E,7,8,9,10,906E,7,8,9,10,Fast,No function assigned here
+PAD7_VelocitySampler,PAD7.VelocitySampler.Start,Pad,9076,7,8,9,10,9076,7,8,9,10,Fast,Sample Slot7 Play
+PAD7_VelocitySampler+Velocity,PAD7.VelocitySampler.Level,Value,B036,7,8,9,10,,,,,,Fast,Sample Slot 7 Level (use Pad velocity)
+PAD7_VelocitySampler+Shift,PAD7.VelocitySampler.Stop,Pad,907E,7,8,9,10,907E,7,8,9,10,Fast,Sample Slot 7 stop
+,,,,,,,,,,,,,,
+PAD8_HotCue,PAD8.HotCue.Call,Pad,9007,7,8,9,10,9007,7,8,9,10,Fast,HOT CUE 8
+PAD8_HotCue+Shift,PAD8.HotCue.Delete,Pad,900F,7,8,9,10,900F,7,8,9,10,Fast,Delete HOT CUE 8
+PAD8_PadFx1,PAD8.PadFx1,Pad,9017,7,8,9,10,9017,7,8,9,10,Fast,PAD FX1 Slot8 (momentary)
+PAD8_PadFx1+Shift,,Pad,901F,7,8,9,10,901F,7,8,9,10,Fast,PAD FX1 Slot8 (momentary)
+PAD8_Slicer,PAD8.Slicer,Pad,9027,7,8,9,10,9027,7,8,9,10,Fast,SLICER 8 Play
+PAD8_Slicer+Shift,,Pad,902F,7,8,9,10,902F,7,8,9,10,Fast,No function assigned here
+PAD8_Sampler,PAD8.Sampler.Start,Pad,9037,7,8,9,10,9037,7,8,9,10,Fast,Sample Slot 8 play
+PAD8_Sampler+Shift,PAD8.Sampler.Stop,Pad,903F,7,8,9,10,903F,7,8,9,10,Fast,Sample Slot 8 stop
+PAD8_BeatJump,PAD8.BeatJump,Pad,9047,7,8,9,10,9047,7,8,9,10,Fast,BEAT JUMP (FWD4)
+PAD8_BeatJump+Shift,,Pad,904F,7,8,9,10,904F,7,8,9,10,Fast,BEAT JUMP (FWD4)
+PAD8_PadFx2,PAD8.PadFx2,Pad,9057,7,8,9,10,9057,7,8,9,10,Fast,PAD FX2 Slot8 (momentary)
+PAD8_PadFx2+Shift,,Pad,905F,7,8,9,10,905F,7,8,9,10,Fast,PAD FX2 Slot8 (momentary)
+PAD8_SlicerLoop,PAD8.SlicerLoop,Pad,9067,7,8,9,10,9067,7,8,9,10,Fast,SLICER LOOP
+PAD8_SlicerLoop+Shift,,Pad,906F,7,8,9,10,906F,7,8,9,10,Fast,No function assigned here
+PAD8_VelocitySampler,PAD8.VelocitySampler.Start,Pad,9077,7,8,9,10,9077,7,8,9,10,Fast,Sample Slot8 Play
+PAD8_VelocitySampler+Velocity,PAD8.VelocitySampler.Level,Value,B037,7,8,9,10,,,,,,Fast,Sample Slot 8 Level (use Pad velocity)
+PAD8_VelocitySampler+Shift,PAD8.VelocitySampler.Stop,Pad,907F,7,8,9,10,907F,7,8,9,10,Fast,Sample Slot 8 stop
+,,,,,,,,,,,,,,
+HotCue,HotCueMode,Button,901B,0,1,2,3,901B,0,1,2,3,Fast,HOT CUE Mode On/Off
+BeatJump,HotCue+Shift,Button,9069,0,1,2,3,9069,0,1,2,3,Fast,BEAT JUMP Mode On/Off
+PadFx1,PadFx1Mode,Button,901E,0,1,2,3,901E,0,1,2,3,Fast,PAD FX1 Mode On/Off
+PadFx2,PadFx1+Shift,Button,906B,0,1,2,3,906B,0,1,2,3,Fast,PAD FX2 Mode On/Off
+Slicer,SlicerMode,Button,9020,0,1,2,3,9020,0,1,2,3,Fast,SLICER Mode On/Off
+SlicerLoop,Slicer+Shift,Button,906D,0,1,2,3,906D,0,1,2,3,Fast,SLICER LOOP Mode On/Off
+Sampler,SamplerMode,Button,9022,0,1,2,3,9022,0,1,2,3,Fast,SAMPLER Mode On/Off
+#Sampler,SamplerMode,Button,9023,0,1,2,3,9023,0,1,2,3,Fast,SAMPLER Mode On/Off
+VelocitySampler,Sampler+LongPress,Button,9041,0,1,2,3,9041,0,1,2,3,Fast,Velocity Mode On/Off
+,,,,,,,,,,,,,,
+Parameter1Left_HotCue,,Button,9024,0,1,2,3,9024,0,1,2,3,,Call Memory Cue (<)
+Parameter2Left_HotCue,Parameter1Left_HotCue+Shift,Button,9001,0,1,2,3,9001,0,1,2,3,,No function assigned here
+Parameter1Left_PadFx1,Parameter1Left.PadFx1,Button,9025,0,1,2,3,9025,0,1,2,3,,Adjust Beat (down)
+Parameter2Left_PadFx1,Parameter1Left_PadFx1+Shift,Button,9002,0,1,2,3,9002,0,1,2,3,,No function assigned here
+Parameter1Left_Slicer,Parameter1Left.Slicer,Button,9026,0,1,2,3,9026,0,1,2,3,,Change Roll (down)
+Parameter2Left_Slicer,Parameter2Left.Slicer,Button,9003,0,1,2,3,9003,0,1,2,3,,Change Domain (down)
+Parameter1Left_Sampler,Parameter1Left.Sampler.BankDown,Button,9027,0,1,2,3,9027,0,1,2,3,,Change Bank (down)
+Parameter2Left_Sampler,Parameter1Left_Sampler+Shift,Button,9004,0,1,2,3,9004,0,1,2,3,,No function assigned here
+Parameter1Left_BeatJump,Parameter1Left.BeatJump,Button,9028,0,1,2,3,9028,0,1,2,3,,Change Jump Range (1/2x)
+Parameter2Left_BeatJump,Parameter1Left_BeatJump+Shift,Button,9005,0,1,2,3,9005,0,1,2,3,,Change Jump Range (1/16x)
+Parameter1Left_PadFx2,Parameter1Left.PadFx2,Button,9029,0,1,2,3,9029,0,1,2,3,,Adjust Beat (down)
+Parameter2Left_PadFx2,Parameter1Left_PadFx2+Shift,Button,9006,0,1,2,3,9006,0,1,2,3,,No function assigned here
+Parameter1Left_SlicerLoop,Parameter1Left.SlicerLoop,Button,902A,0,1,2,3,902A,0,1,2,3,,Change Roll (down)
+Parameter2Left_SlicerLoop,Parameter2Left.SlicerLoop,Button,9007,0,1,2,3,9007,0,1,2,3,,Change Domain (down)
+Parameter1Left_VelocitySampler,Parameter1Left.VelocitySampler.BankDown,Button,902B,0,1,2,3,902B,0,1,2,3,,Change Bank (down)
+Parameter2Left_VelocitySampler,Parameter1Left_VelocitySampler+Shift,Button,9008,0,1,2,3,9008,0,1,2,3,,No function assigned here
+,,,,,,,,,,,,,,
+Parameter1Right_HotCue,,Button,902C,0,1,2,3,902C,0,1,2,3,,Call Memory Cue (>)
+Parameter2Right_HotCue,Parameter1Right_HotCue+Shift,Button,9009,0,1,2,3,9009,0,1,2,3,,No function assigned here
+Parameter1Right_PadFx1,Parameter1Right.PadFx1,Button,902D,0,1,2,3,902D,0,1,2,3,,Adjust Beat (up)
+Parameter2Right_PadFx1,Parameter1Right_PadFx1+Shift,Button,907A,0,1,2,3,907A,0,1,2,3,,No function assigned here
+Parameter1Right_Slicer,Parameter1Right.Slicer,Button,902E,0,1,2,3,902E,0,1,2,3,,Change Roll (up)
+Parameter2Right_Slicer,Parameter2Right.Slicer,Button,907B,0,1,2,3,907B,0,1,2,3,,Change Domain (up)
+Parameter1Right_Sampler,Parameter1Right.Sampler.BankUp,Button,902F,0,1,2,3,902F,0,1,2,3,,Change Bank (up)
+Parameter2Right_Sampler,Parameter1Right_Sampler+Shift,Button,907C,0,1,2,3,907C,0,1,2,3,,No function assigned here
+Parameter1Right_BeatJump,Parameter1Right.BeatJump,Button,9030,0,1,2,3,9030,0,1,2,3,,Change Jump Range (2x)
+Parameter2Right_BeatJump,Parameter1Right_BeatJump+Shift,Button,907D,0,1,2,3,907D,0,1,2,3,,Change Jump Range (16x)
+Parameter1Right_PadFx2,Parameter1Right.PadFx2,Button,9031,0,1,2,3,9031,0,1,2,3,,Adjust Beat (up)
+Parameter2Right_PadFx2,Parameter1Right_PadFx2+Shift,Button,907E,0,1,2,3,907E,0,1,2,3,,No function assigned here
+Parameter1Right_SlicerLoop,Parameter1Right.SlicerLoop,Button,9032,0,1,2,3,9032,0,1,2,3,,Change Roll (up)
+Parameter2Right_SlicerLoop,Parameter1Right_SlicerLoop+Shift,Button,907F,0,1,2,3,907F,0,1,2,3,,Change Domain (up)
+Parameter1Right_VelocitySampler,Parameter1Right.VelocitySampler.BankUp,Button,9033,0,1,2,3,9033,0,1,2,3,,Change Bank (up)
+Parameter2Right_VelocitySampler,Parameter1Right_VelocitySampler+Shift,Button,9000,0,1,2,3,9000,0,1,2,3,,No function assigned here
+,,,,,,,,,,,,,,
+SamplerVolume,SamplerVolume,KnobSliderHiRes,B603,,,,,,,,,,,Sampler Volume
+SamplerVolume,SamplerVolume+Shift,KnobSlider,B669,,,,,,,,,,,Sampler Volume
+,,,,,,,,,,,,,,
+# Others,,,,,,,,,,,,,,
+FxPanel,FxPanel,Button,9678,,,,,,,,,,,Display FX panel (Type1-3) -> OFF -> ...(cyclic)
+SamplerPanel,FxPanel+Shift,Button,9679,,,,,,,,,,,Display SAMPLER panel (Type1-3) -> OFF -> ...(cyclic)
+,,,,,,,,,,,,,,
+# State,,,,,,,,,,,,,,
+DeckState,DeckState,Button,903C,0,1,2,3,,,,,,RO,LED State of the DECK 1/2/3/4
+DualDeckState13,DualDeckState13,Button,967A,,,,,,,,,,RO,LED State of the DUAL DECK button (Deck1 and Deck3)
+DualDeckState24,DualDeckState24,Button,967B,,,,,,,,,,RO,LED State of the DUAL DECK button (Deck2 and Deck4)
+VinylState,VinylState,Button,903A,0,1,2,3,,,,,,RO,LED State of the Vinyl buttons
+#,SlipState,Button,903B,0,1,2,3,,,,,,RO,LED State of the SLIP buttons
+SlipStateForFlashing,SlipStateForFlashing,Indicator,,,,,,903E,0,1,2,3,RO,SLIP on/off state for SLIP Mode Flashing
+#,PlayPauseStateForNeedle,Indicator,,,,,,900F,0,1,2,3,RO,Play/Pause state for Needle Search Lock
+,,,,,,,,,,,,,,
+# illumination,,,,,,,,,,,,,,
+LoadedIndicator,LoadedIndicator,Indicator,,,,,,,9B00,9B01,9B02,9B03,RO;Priority=100,Trigger for Load illumination
+JogPlayPauseIndicatorShort,JogPlayPauseIndicatorShort,JogIndicator,,,,,,,BB00,BB01,BB02,BB03,RO;Min=1;Max=72;Priority=100,Playing States for the trigger for JOG illumination
+EndWarningIndicator,EndWarningIndicator,Indicator,,,,,,,9B04,9B05,9B06,9B07,RO;Priority=100,Trigger for ending illumination of playback
+,,,,,,,,,,,,,,
+# Parameter,,,,,,,,,,,,,,
+JogIndicatorInterval,JogIndicatorInterval,Parameter,FFF1,,,,,,,,,,Value=12,
+JogRatency,JogRatency,Parameter,FFF2,,,,,,,,,,Value=4,unused
+MidiOutInterval,MidiOutInterval,Parameter,FFF3,,,,,,,,,,Value=2,

--- a/test_midi_input.py
+++ b/test_midi_input.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Quick test: list all MIDI devices and try to receive from S2 MK3."""
+import mido
+
+print("=== Available MIDI Inputs ===")
+for name in mido.get_input_names():
+    print(f"  IN:  {name}")
+
+print("\n=== Available MIDI Outputs ===")
+for name in mido.get_output_names():
+    print(f"  OUT: {name}")
+
+print("\n=== Available MIDI I/O Ports ===")
+for name in mido.get_ioport_names():
+    print(f"  I/O: {name}")
+
+# Try opening as plain input
+print("\nTrying to open S2 MK3 as INPUT (not ioport)...")
+try:
+    inp = mido.open_input("Traktor Kontrol S2 MK3")
+    print("SUCCESS! Listening for 10 seconds -- touch a jogwheel or press a button...")
+    import time
+    start = time.time()
+    while time.time() - start < 10:
+        msg = inp.poll()
+        if msg:
+            print(f"  >> {msg}  |  raw: {' '.join(f'0x{b:02X}' for b in msg.bytes())}")
+    inp.close()
+    print("Done.")
+except Exception as e:
+    print(f"FAILED: {e}")


### PR DESCRIPTION
Adds a translator for the Native Instruments Traktor Kontrol S2 MK3 (`RekordJog_KontrolS2MK3.py`), reusing the existing DDJ-SX MIDI-out approach.

**Status: work in progress.** Core functionality has been tested on real hardware and works: jogwheels (rotation + touch), tempo faders, deck buttons + shift layer, performance pads (incl. shift), browse encoder, loop/move encoders (incl. shift -> BeatJump), mixer faders/EQ/gain, crossfader, headphone cue, FX select + FX/filter knob, load button.

**Known limitation:** the browse encoder's press action (`BROWSE_PRESS_NOTE`) is not yet mapped - the exact MIDI note it sends hasn't been identified. It's left disabled (`None`) rather than guessed.

Also includes:
- Expanded `pioneer_mappings/PIONEER DDJ-SX.midi.csv` (browser, deck, loop, hot cue, FX, sampler, mixer, pad modes) needed for the new controls
- Three helper scripts used to reverse-engineer the mapping (`capture_s2mk3_midi.py`, `learn_buttons.py`, `test_midi_input.py`), kept in case someone wants to finish the browse-press mapping or extend this further
- README updated: device added to the supported list, new setup/usage section, limitation documented
- `.gitignore`: ignore leftover `*.broken` files
- Small comment fix in `RekordJog_KontrolS2MK3.py` (the `LOAD_NOTE` comment still said "once identified" after it already had been)

Opening this now as a starting point / for early feedback, rather than waiting until it's 100% complete.